### PR TITLE
Fix/proposal serializer extends

### DIFF
--- a/lib/decidim/phone_authorization_handler/extends/proposal_serializer_extend.rb
+++ b/lib/decidim/phone_authorization_handler/extends/proposal_serializer_extend.rb
@@ -70,7 +70,11 @@ module Decidim::PhoneAuthorizationHandler
           phone_number: ""
         }
         if proposal.creator.decidim_author_type == "Decidim::UserBaseEntity"
-          user = Decidim::User.find proposal.creator_author.id
+          begin
+            user = Decidim::User.find proposal.creator_author.id
+          rescue ActiveRecord::RecordNotFound
+            user = Decidim::UserGroup.find proposal.creator_author.id
+          end
 
           author_metadata[:name] = user.try(:name).presence || ""
           author_metadata[:nickname] = user.try(:nickname).presence || ""

--- a/spec/services/decidim/proposals/proposal_serializer_spec.rb
+++ b/spec/services/decidim/proposals/proposal_serializer_spec.rb
@@ -162,6 +162,27 @@ module Decidim
             expect(serialized[:author][:phone_number]).not_to be_empty
           end
 
+          context "and proposal has user_group as author" do
+            let!(:proposal) { create(:proposal, :user_group_author, :accepted) }
+
+            before do
+              proposal.coauthorships.clear
+              user = create(:user, organization: proposal.component.participatory_space.organization)
+              user_group = create(:user_group, :verified, organization: user.organization, users: [user])
+              proposal.coauthorships.create(author: user_group)
+            end
+
+            it "serializes author" do
+              expect(serialized).to include(:author)
+            end
+
+            it "data in author are not empty" do
+              expect(serialized[:author][:name]).not_to be_empty
+              expect(serialized[:author][:nickname]).not_to be_empty
+              expect(serialized[:author][:email]).not_to be_empty
+            end
+          end
+
           context "when proposal was created by admin from backoffice" do
             let!(:admin) { create(:user, :admin) }
 


### PR DESCRIPTION
🎩 Description
Fix author_data method in proposal_serializer_extend to handle the case of a proposal with UserGroup as author (case encountered in decidim-tou)

📌 Related Issues
- [Odoo card](https://opensourcepolitics.odoo.com/web#id=2491&cids=1&menu_id=325&action=471&model=project.task&view_type=form)

#### Tasks
- [X ] Add specs